### PR TITLE
Fix properties in PCA, Pearson, Logistic Regression

### DIFF
--- a/Exareme-Docker/src/mip-algorithms/LOGISTIC_REGRESSION/properties.json
+++ b/Exareme-Docker/src/mip-algorithms/LOGISTIC_REGRESSION/properties.json
@@ -57,22 +57,10 @@
             "valueType": "string"
         },
         {
-            "name": "max_iter",
-            "desc": "Maximum number of iterations. Must be a positive integer.",
-            "type": "other",
-            "value": "",
-            "defaultValue": "20",
-            "valueNotBlank": false,
-            "valueMultiple": false,
-            "valueType": "integer",
-            "valueMin": 1,
-            "valueMax": 100
-        },
-        {
             "name": "formula",
             "desc": "Patsy formula  (R language syntax).",
             "type": "other",
-            "value": "gender _ alzheimerbroadcategory * lefthippocampus",
+            "value": "",
             "defaultValue": "",
             "valueNotBlank": false,
             "valueMultiple": false,

--- a/Exareme-Docker/src/mip-algorithms/LOGISTIC_REGRESSION/termination_condition/global.py
+++ b/Exareme-Docker/src/mip-algorithms/LOGISTIC_REGRESSION/termination_condition/global.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 import sys
 from os import path
+
 from argparse import ArgumentParser
 
 sys.path.append(path.dirname(path.dirname(path.dirname(path.abspath(__file__)))) + '/utils/')
@@ -13,11 +14,13 @@ sys.path.append(path.dirname(path.dirname(path.dirname(path.abspath(__file__))))
 from algorithm_utils import StateData, set_algorithms_output_data
 from log_regr_lib import PREC
 
+_MAX_ITER = 40
 
-def termination_condition(global_state, max_iter):
+
+def termination_condition(global_state):
     delta = global_state['delta']
     iter_ = global_state['iter_']
-    if delta < PREC or iter_ >= max_iter:
+    if delta < PREC or iter_ >= _MAX_ITER:
         set_algorithms_output_data('STOP')
     else:
         set_algorithms_output_data('CONTINUE')
@@ -28,13 +31,11 @@ def main():
     parser = ArgumentParser()
     parser.add_argument('-prev_state_pkl', required=True,
                         help='Path to the pickle file holding the previous state.')
-    parser.add_argument('-max_iter', type=int, required=True, help='Maximum number of iterations.')
     args, unknown = parser.parse_known_args()
     fname_prev_state = path.abspath(args.prev_state_pkl)
-    max_iter = args.max_iter
 
     global_state = StateData.load(fname_prev_state).data
-    termination_condition(global_state, max_iter)
+    termination_condition(global_state)
 
 
 if __name__ == '__main__':

--- a/Exareme-Docker/src/mip-algorithms/PCA/pca_lib.py
+++ b/Exareme-Docker/src/mip-algorithms/PCA/pca_lib.py
@@ -35,7 +35,6 @@ def get_data(args):
     query_filter = args.filter
     formula = args.formula
     formula = formula.replace('_', '~')  # TODO Fix tilda problem and remove
-    no_intercept = json.loads(args.no_intercept)
     data_table = args.data_table
     metadata_table = args.metadata_table
     metadata_code_column = args.metadata_code_column
@@ -51,7 +50,7 @@ def get_data(args):
                               metadata_table=metadata_table,
                               metadata_code_column=metadata_code_column,
                               metadata_isCategorical_column=metadata_isCategorical_column,
-                              no_intercept=no_intercept,
+                              no_intercept=True,
                               coding=None)
 
     return X

--- a/Exareme-Docker/src/mip-algorithms/PCA/properties.json
+++ b/Exareme-Docker/src/mip-algorithms/PCA/properties.json
@@ -48,7 +48,7 @@
             "name": "formula",
             "desc": "Patsy formula  (R language syntax).",
             "type": "other",
-            "value": "leftaccumbensarea + leftacgganteriorcingulategyrus * leftainsanteriorinsula",
+            "value": "",
             "defaultValue": "",
             "valueNotBlank": false,
             "valueMultiple": false,

--- a/Exareme-Docker/src/mip-algorithms/PCA/properties.json
+++ b/Exareme-Docker/src/mip-algorithms/PCA/properties.json
@@ -55,20 +55,6 @@
             "valueType": "string"
         },
         {
-            "name": "no_intercept",
-            "desc": "Boolean flag for having no intercept by default.",
-            "type": "other",
-            "value": "true",
-            "defaultValue": "false",
-            "valueNotBlank": false,
-            "valueMultiple": false,
-            "valueType": "string",
-            "enumValues": [
-                "true",
-                "false"
-            ]
-        },
-        {
             "name": "coding",
             "desc": "Coding method for categorical variables.",
             "type": "other",

--- a/Exareme-Docker/src/mip-algorithms/PEARSON_CORRELATION/properties.json
+++ b/Exareme-Docker/src/mip-algorithms/PEARSON_CORRELATION/properties.json
@@ -53,48 +53,6 @@
             "valueNotBlank": false,
             "valueMultiple": true,
             "valueType": "string"
-        },
-        {
-            "name": "formula",
-            "desc": "Patsy formula  (R language syntax).",
-            "type": "other",
-            "value": "agegroup + gender _ leftaccumbensarea + leftacgganteriorcingulategyrus + leftainsanteriorinsula",
-            "defaultValue": "",
-            "valueNotBlank": false,
-            "valueMultiple": false,
-            "valueType": "string"
-        },
-        {
-            "name": "no_intercept",
-            "desc": "Boolean flag for having no intercept by default.",
-            "type": "other",
-            "value": "true",
-            "defaultValue": "true",
-            "valueNotBlank": false,
-            "valueMultiple": false,
-            "valueType": "string",
-            "enumValues": [
-                "true",
-                "false"
-            ]
-        },
-        {
-            "name": "coding",
-            "desc": "Coding method for categorical variables.",
-            "type": "other",
-            "value": "null",
-            "defaultValue": "null",
-            "valueNotBlank": false,
-            "valueMultiple": false,
-            "valueType": "string",
-            "enumValues": [
-                "null",
-                "Treatment",
-                "Diff",
-                "Poly",
-                "Sum",
-                "Helmert"
-            ]
         }
     ]
 }


### PR DESCRIPTION
- Remove formula from `PEARSON_CORRELATION`
- Remove `no_intercept` and default formula from `PCA`
- Remove `max_iter` and default formula from `LOGISTIC_REGRESSION`