### PR TITLE
Update documentation.

### DIFF
--- a/Documentation/InputRequirements.md
+++ b/Documentation/InputRequirements.md
@@ -24,7 +24,7 @@ The metadata file should follow these rules:
 		</ul>
 	</li>
 </ul>
-An example can be seen here: https://github.com/madgik/exareme/blob/master/Exareme-Docker/src/mip-algorithms/unit_tests/data/dementia/CDEsMetadata.json .
+An example can be seen here: https://github.com/madgik/exareme/blob/master/Exareme-Docker/src/mip-algorithms/tests/data/dementia/CDEsMetadata.json .
 
 
 ## CSV Files

--- a/Exareme-Docker/src/mip-algorithms/tests/data/README.md
+++ b/Exareme-Docker/src/mip-algorithms/tests/data/README.md
@@ -1,10 +1,14 @@
-In that folder you will find sub-folders for *each pathology* containing data (CSVs) for running the Experiments. In each pathology folder you will also find a .json file called
+In this folder you will find sub-folders for *each pathology* containing data (CSVs) for running the Experiments.<br/>
+In each pathology folder you will also find a .json file called
 ```CDEsMetadata.json``` containing all the metadata of the data, important -among others- for the pre-execution of the Experiments. 
 
-In order for you to add a dataset in the whole process, you need to add it inside the *pathology folder* and add its metadata in the corresponding CDEsMetadata.json.
+In order for you to add a dataset in the whole process, you need to add it inside the *pathology folder* and add its metadata in the corresponding ```CDEsMetadata.json```.
 
-The python script called ```splitCSVFiles.py``` will split the datasets in N datasets one for each node you have. Run:
-```python3 ./splitCSVFiles.py -p *N* -fp *pathology*/ -mp *pathology*/CDEsMetadata.json``` for splitting the datasets existing in each pathology, where *N* the number of splits and *pathology* the pathology folder, in that case *dementia*,*tbi*.
+Then, you have to split the datasets of a *pathology* in *N* datasets, one for each node you have in your cluster.<br/>
+To achieve this, you can run:<br/>
+```python3 ./splitCSVFiles.py -p *N* -fp *pathology*/ -mp *pathology*/CDEsMetadata.json```<br/>
+In the above command, *N* is the number of splits and *pathology* is the *pathology folder*, for example: *dementia*, *tbi*.<br/>
+The output is a folder named ```output```, which contains the created datasets.<br/>
 
-The ```pathologies.json``` is used from the front end and it is created from the pathologies, their metadata and the datasets available.
+The ```pathologies.json``` is used from the front-end and it is created from the pathologies, their metadata and the datasets available.
 The creation of it could be automated in the future.

--- a/Federated-Deployment/Documentation/Optionals.md
+++ b/Federated-Deployment/Documentation/Optionals.md
@@ -8,7 +8,7 @@ The file should contain the following lines, modify them depending on the versio
 
 ```
 EXAREME_IMAGE: "hbpmip/exareme"
-EXAREME_TAG: "v22.0.1"
+EXAREME_TAG: "22.0.1"
 ```
 
 # [Optional] Initialize Hosts

--- a/Federated-Deployment/Documentation/Optionals.md
+++ b/Federated-Deployment/Documentation/Optionals.md
@@ -8,7 +8,7 @@ The file should contain the following lines, modify them depending on the versio
 
 ```
 EXAREME_IMAGE: "hbpmip/exareme"
-EXAREME_TAG: "v21.2.0"
+EXAREME_TAG: "v22.0.1"
 ```
 
 # [Optional] Initialize Hosts
@@ -55,12 +55,13 @@ worker88_197_53_100 become_user="{{worker88_197_53_100_become_user}}"
 worker88_197_53_100 ansible_become_pass="{{worker88_197_53_100_become_pass}}"
 worker88_197_53_100 ansible_ssh_pass="{{worker88_197_53_100_ssh_pass}}"
 ```
-You can find the hostname of any machine by executing ```hostname``` in terminal. Please mind that the ```hostname``` of the Target node *Must Not* include dashes[.] If that is the case, change your hostname configurations in the Target node as needed.
+You can find the hostname of any machine by executing ```hostname``` in terminal.<br/>
 
-[Requirement1: Mind that the variable ```data_path``` is the path where pathology folders are stored in your Target machine (Each Pathology folder includes the Data CSV (datasets.csv) and the Metadata file (CDEsMetadata.json))]<br/>
-
-[Requirement2: Mind that the variable ```home_path``` is the path where ```Federated-Deployment/Compose-Files/``` will be copied and stored in the master node. Compose-Files contains 2 docker-compose.yaml files for deploying the services.
-The ```home_path``` can be Any path in which become_user has permissions. If the path does not exist in the master node,then any sub-folders are created automatically during the copy.]<br/>
+Please follow these requirements:
+1) Mind that the ```hostname``` of the Target node *Must Not* include dashes ( **.** ) If that is the case, change your hostname configurations in the Target node as needed.
+2) Mind that the variable ```data_path``` is the path where pathology folders are stored in your Target machine (Each Pathology folder includes the Data CSV (datasets.csv) and the Metadata file (CDEsMetadata.json))
+3) Mind that the variable ```home_path``` is the path where ```Federated-Deployment/Compose-Files/``` will be copied and stored in the master node. Compose-Files contains 2 docker-compose.yaml files for deploying the services.
+The ```home_path``` can be Any path in which become_user has permissions. If the path does not exist in the master node,then any sub-folders are created automatically during the copy.
 
 You can see that there are 2 main categories in hosts.ini file. The first one is ```[master]```, the second one is ```[workers]```. <br/>
 You can always add more workers following the template given above: </br>
@@ -109,13 +110,13 @@ As you can also see in hosts.ini file we have some sensitive data like usernames
 ```
 
 It is not a valid technique to just fill in your sensitive data (credentials) there, so we will use ```Ansible-Vault```.
-Ansible-vault comes with the installation of ansible. Make sure you have it installed by running: ```ansible-vault --version```
+Ansible-vault comes with the installation of ```ansible```. Make sure you have it installed by running: ```ansible-vault --version```
 
 With ansible-vault we can have an encrypted file which will contain sensitive information (credentials) like the ones shown above.
 
-In order to create the file you need to run
+In order to create the file, you need to run
 ```ansible-vault create vault.yaml``` inside ```Federated-Deployment/Docker-Ansible/``` folder.
-It will ask for a vault-password that you will need to enter it each time you run a playbook. So keep it in mind.
+It will ask for a vault-password which you will need to enter each time you run a playbook. So keep it in mind.
 
 Here you will add
 ```
@@ -138,15 +139,18 @@ all in plaintext where:<br/>
 a)remote_user and ssh_pass will be user to login to the target hostname<br/>
 b)become_user and become_pass will be used to execute docker and other commands. Make sure that become_user has permission to run docker commands (add user to docker group in the target machines).You could use root for become_user if possible.
 <br/><br/>
-Keep in mind that you must be able to ```ssh remote_user@ansible_host``` in *all target machines* by only providing the ```ssh_pass``` as a password.If this is not the case, consider to change your ssh configurations.
+Keep in mind that you must be able to ```ssh remote_user@ansible_host``` in *all target machines* by only providing the ```ssh_pass``` as a password. If this is not the case, consider to change your ssh configurations.
 
 If you have more than 2 workers, you will add those too by adding ```workerX_...``` in front of each variable where X is the IP of the node with ```.``` replaced by ```_```.<br/>
 [Keep in mind that your password can be anything you want But ansible has a special character for comments ```#``` . If your password contains that specific character ansible will take the characters next to it as comments.]<br/>
 When you exit you can see that vault.yaml is encrypted with all your sensitive information (credentials) in there.
 
 If you want to edit the file you can do so whenever by running:
-```ansible-vault edit vault.yaml```
+```ansible-vault edit vault.yaml```<br/>
 Place your vault password and edit the file.
+
+Note: ```ansible``` uses the ```vim``` editor by default, you may use a different editor (like ```nano```) by applying ```env EDITOR=nano``` right before the ```ansible-vault``` commands.<br/>
+For example: ```env EDITOR=nano ansible-vault edit vault.yaml```
 
 ## [Optional] Regarding Ansible-vault password.
 (source https://docs.ansible.com/ansible/latest/user_guide/playbooks_vault.html)


### PR DESCRIPTION
Updates in "Optionals.md":
 - Updated the suggested exereme-version in "exareme.yaml", important for the deployment to work.
 - Added a note for the ability to use the "nano" editor when editing the ansible-vault file, for people finding it difficult to work with "vim", which is the default editor for ansible.
 - Small text-layout improvements.

Other:
 - Fix a broken-link in "InputRequirements.md".
 - Update the README for splitting the test datasets.