### PR TITLE
Fix for k8s single node deployment.

### DIFF
--- a/Federated-Deployment/kubernetes/templates/exareme-worker.yaml
+++ b/Federated-Deployment/kubernetes/templates/exareme-worker.yaml
@@ -1,3 +1,4 @@
+{{ if gt .Values.workers 1.0}} # Single node deployment
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -57,3 +58,4 @@ spec:
       - name: data
         hostPath:
           path: {{ .Values.data_path }}
+{{end}}


### PR DESCRIPTION
The worker doesn't need to be started if there is only one node. The master node will be used as worker.